### PR TITLE
Update portsentry.conf for not 2 kill rules

### DIFF
--- a/templates/etc/portsentry/portsentry.conf.j2
+++ b/templates/etc/portsentry/portsentry.conf.j2
@@ -248,7 +248,7 @@ KILL_ROUTE="{{ portsentry_kill_route }}"
 # options, but be sure you escape all '%' symbols with a backslash
 # to prevent problems writing out (i.e. \%c \%h )
 #
-KILL_HOSTS_DENY="ALL: $TARGET$ : DENY"
+#KILL_HOSTS_DENY="ALL: $TARGET$ : DENY"
 
 ###################
 # External Command#


### PR DESCRIPTION
There were 2 "kill" rules, that's a lot ... as soon as there is a ban there is an iptables rule + a line in the hosts.deny (the latter is not when it is full greatly slows down the system performance)